### PR TITLE
Explicitly specified schema for content_languages column in CCIndex

### DIFF
--- a/src/main/scala/cc/idx/CCIdxMain.scala
+++ b/src/main/scala/cc/idx/CCIdxMain.scala
@@ -4,20 +4,66 @@ import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Dataset, DataFrame}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.{StructType, StructField, IntegerType, TimestampType, StringType, ShortType}
 
 object CCIdxMain {
     def main(args: Array[String]): Unit = {
-		val tablePath = "s3a://commoncrawl/cc-index/table/cc-main/warc/"
+		val conf = new SparkConf()
+			.setAppName(this.getClass.getCanonicalName())
+			.set("spark.hadoop.parquet.enable.dictionary", "true")
+			.set("spark.hadoop.parquet.enable.summary-metadata", "true")
+			.set("spark.sql.hive.metastorePartitionPruning", "true")
+			.set("spark.sql.parquet.filterPushdown", "true")
+
+		val spark = SparkSession.builder.master("local[*]")
+			.config(conf)
+			.getOrCreate
+
+		val sc = spark.sparkContext
+
+		val tablePath = "s3a://commoncrawl/cc-index/table/cc-main/warc"
 		val viewName = "ccindex"
-			val sqlQuery = "Select * From " + viewName + " Where crawl=\'CC-MAIN-2021-10\' And subset=\'warc\' AND url RLIKE \'.*(/job/|/jobs/|/careers/|/career/).*\'"
-
-
-			val conf = new SparkConf().setAppName(this.getClass.getCanonicalName())
-			val spark = SparkSession.builder.master("local[*]").config(conf).getOrCreate
-			val sc = spark.sparkContext
-		val df = spark.read.load(tablePath)
+		val schema = StructType(Array(
+			StructField("url_surtkey", StringType, true),
+			StructField("url", StringType, true),
+			StructField("url_host_name", StringType, true),
+			StructField("url_host_tld", StringType, true),
+			StructField("url_host_2nd_last_part", StringType, true),
+			StructField("url_host_3rd_last_part", StringType, true),
+			StructField("url_host_4th_last_part", StringType, true),
+			StructField("url_host_5th_last_part", StringType, true),
+			StructField("url_host_registry_suffix", StringType, true),
+			StructField("url_host_registered_domain", StringType, true),
+			StructField("url_host_private_suffix", StringType, true),
+			StructField("url_host_private_domain", StringType, true),
+			StructField("url_protocol", StringType, true),
+			StructField("url_port", IntegerType, true),
+			StructField("url_path", StringType, true),
+			StructField("url_query", StringType, true),
+			StructField("fetch_time", TimestampType, true),
+			StructField("fetch_status", ShortType, true),
+			StructField("fetch_redirect", StringType, true),
+			StructField("content_digest", StringType, true),
+			StructField("content_mime_type", StringType, true),
+			StructField("content_mime_detected", StringType, true),
+			StructField("content_charset", StringType, true),
+			StructField("content_languages", StringType, true),
+			StructField("content_truncated", StringType, true),
+			StructField("warc_filename", StringType, true),
+			StructField("warc_record_offset", IntegerType, true),
+			StructField("warc_record_length", IntegerType, true),
+			StructField("warc_segment", StringType, true),
+			StructField("crawl", StringType, true),
+			StructField("subset", StringType, true)
+		))
+		val df = spark.read.schema(schema).parquet(tablePath)
+		df.printSchema()
+		//val sqlQuery = "Select * From " + viewName + " Where crawl=\'CC-MAIN-2021-10\' And subset=\'warc\' AND url RLIKE \'.*(/job/|/jobs/|/careers/|/career/).*\'"
+		val sqlQuery = "Select url, content_languages From " + viewName + " Where crawl=\'CC-MAIN-2021-10\' And subset=\'warc\' AND url_host_tld=\'va\'"
 		df.createOrReplaceTempView(viewName)
-		spark.sql(sqlQuery).show
+
+		spark.sql("describe formatted " + viewName).show(10000)
+		spark.sql(sqlQuery).show(100)
 
 		spark.stop
 

--- a/src/main/scala/cc/idx/indexUtil.scala
+++ b/src/main/scala/cc/idx/indexUtil.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.SparkSession
 object IndexUtil {
 
     val tablePath = "s3a://commoncrawl/cc-index/table/cc-main/warc/"
-    val formats = Set[String]("warc", "wat", "wet")
+    val subsets = Set[String]("warc", "robotstxt", "crawldiagnostics")
     val crawls = Set[String](
         "CC-MAIN-2013-20", "CC-MAIN-2013-48", "CC-MAIN-2014-10", "CC-MAIN-2014-15", "CC-MAIN-2014-23", "CC-MAIN-2014-35", "CC-MAIN-2014-41", "CC-MAIN-2014-42", "CC-MAIN-2014-49", "CC-MAIN-2014-52", 
         "CC-MAIN-2015-06", "CC-MAIN-2015-11", "CC-MAIN-2015-14", "CC-MAIN-2015-18", "CC-MAIN-2015-22", "CC-MAIN-2015-27", "CC-MAIN-2015-32", "CC-MAIN-2015-35", "CC-MAIN-2015-40", "CC-MAIN-2015-48", 
@@ -45,15 +45,15 @@ object IndexUtil {
         }
     }
 
-    def filter(index_df: DataFrame, crawl: String, format: String, filter_exprs: Column=null): DataFrame = {
+    def filter(index_df: DataFrame, crawl: String, subset: String, filter_exprs: Column=null): DataFrame = {
 
         if (!crawls.contains(crawl)) throw new IllegalArgumentException(s"Invalid crawl ${crawl}")
-        if (!formats.contains(format)) throw new IllegalArgumentException(s"Invalid format ${format}. Must be one of ${formats.mkString(", ")}")
+        if (!subsets.contains(subset)) throw new IllegalArgumentException(s"Invalid subset ${subset}. Must be one of ${subsets.mkString(", ")}")
 
         if (filter_exprs != null)
-            return index_df.where(index_df("crawl") === crawl && index_df("subset") === format).where(filter_exprs)
+            return index_df.where(index_df("crawl") === crawl && index_df("subset") === subset).where(filter_exprs)
         
-        return index_df.where(index_df("crawl") === crawl && index_df("subset") === format)
+        return index_df.where(index_df("crawl") === crawl && index_df("subset") === subset)
     }
 
     def merge(index_dfs: DataFrame*): DataFrame = {


### PR DESCRIPTION
Previously, several columns including `content_languages` were missing due to incompatible schema, since `content_languages` was only introduced since the September 2018 crawl (CC-MAIN-2018-39). Refer to https://commoncrawl.s3.amazonaws.com/cc-index/table/cc-main/index.html for details.

The fix here is to explicitly declare the table schema and include the column `content_languages`, plus others.